### PR TITLE
chore(build): Update angularfire2 to the next tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
-    "e2e": "protractor"
+    "e2e": "protractor",
+    "aot": "./node_modules/.bin/ngc -p src/tsconfig.json"
   },
   "private": true,
   "dependencies": {
@@ -21,7 +22,7 @@
     "@angular/platform-browser": "^2.3.1",
     "@angular/platform-browser-dynamic": "^2.3.1",
     "@angular/router": "^3.3.1",
-    "angularfire2": "^2.0.0-beta.6",
+    "angularfire2": "^2.0.0-beta.7-next",
     "core-js": "^2.4.1",
     "rxjs": "^5.0.1",
     "ts-helpers": "^1.1.1",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -14,5 +14,8 @@
     "typeRoots": [
       "../node_modules/@types"
     ]
-  }
+  },
+  "files": [
+    "main"
+  ]
 }


### PR DESCRIPTION
This issue makes AngularFire2 AOT compatible, and the `next` tag includes this fix.

I've updated the repo to use this tag and I've verified that it generates the factories without any errors.

@StephenFluin Can you run it and make sure I've included everything?